### PR TITLE
Backend

### DIFF
--- a/backend/src/api/components/users/user.controller.js
+++ b/backend/src/api/components/users/user.controller.js
@@ -324,6 +324,38 @@ export async function editUserBanner(req, res) {
   }
 }
 
+export async function setUserDefaultProfilePhoto(req, res) {
+  try {
+    const userId = parseInt(req.params.id);
+    if (userId !== req.user.id) {
+      return res.status(403).json({ erro: "Você só pode editar sua própria foto." });
+    }
+
+    const DEFAULT_PROFILE_URL = "https://res.cloudinary.com/dupalmuyo/image/upload/v1751246125/foto-perfil-padrao-usuario-2_f0ghzz.png";
+    const updateResult = await userService.updateUserProfilePhoto(userId, DEFAULT_PROFILE_URL);
+
+    return res.status(200).json({ ...updateResult, fotoPerfil: DEFAULT_PROFILE_URL });
+  } catch (error) {
+    return res.status(400).json({ erro: error.message });
+  }
+}
+
+export async function setUserDefaultBanner(req, res) {
+  try {
+    const userId = parseInt(req.params.id);
+    if (userId !== req.user.id) {
+      return res.status(403).json({ erro: "Você só pode editar seu próprio banner." });
+    }
+
+    const DEFAULT_BANNER_URL = "https://res.cloudinary.com/dupalmuyo/image/upload/v1751246166/banner-padrao-1_lbhrjv.png";
+    const updateResult = await userService.updateUserBanner(userId, DEFAULT_BANNER_URL);
+
+    return res.status(200).json({ ...updateResult, bannerPerfil: DEFAULT_BANNER_URL });
+  } catch (error) {
+    return res.status(400).json({ erro: error.message });
+  }
+}
+
 export default {
   registerUser,
   loginUser,
@@ -334,5 +366,7 @@ export default {
   getPublicUserProfile,
   editUserProfile,
   editUserProfilePhoto,
-  editUserBanner
+  editUserBanner,
+  setUserDefaultProfilePhoto,
+  setUserDefaultBanner
 };

--- a/backend/src/api/routes/user.routes.js
+++ b/backend/src/api/routes/user.routes.js
@@ -29,6 +29,9 @@ router.post("/usuario/:id/banner",
   userController.editUserBanner
 );
 
+router.post("/usuario/:id/foto-default", verifyToken, userController.setUserDefaultProfilePhoto);
+router.post("/usuario/:id/banner-default", verifyToken, userController.setUserDefaultBanner);
+
 // 🔧 DEBUG/UTILITY: List all users (keep protected if needed)
 router.get("/usuarios", async (req, res) => {
   try {


### PR DESCRIPTION
Este pull request introduz dois novos endpoints para permitir que os usuários redefinam a foto do perfil e o banner para as imagens padrão. Ele também atualiza o controlador e as rotas para dar suporte a essas funcionalidades.

### Novos recursos:

* **Métodos do controlador para imagens padrão**:
  - Adicionado o método `setUserDefaultProfilePhoto` para redefinir a foto do perfil de um usuário para um URL padrão. Inclui validação para garantir que os usuários só possam atualizar sua própria foto de perfil.
  - Adicionado o método `setUserDefaultBanner` para redefinir o banner de um usuário para um URL padrão. Inclui validação para garantir que os usuários só possam atualizar seu próprio banner.

**Atualizações de rota**:
  - Adicionada uma rota POST `/usuario/:id/foto-default` para acionar o método `setUserDefaultProfilePhoto`.
  - Adicionada uma rota POST `/usuario/:id/banner-default` para acionar o método `setUserDefaultBanner`.